### PR TITLE
Dont touch hidden files/directories in sync directories

### DIFF
--- a/lib/RoomAssets/App/Command/sync.pm
+++ b/lib/RoomAssets/App/Command/sync.pm
@@ -437,7 +437,7 @@ sub fetch_resource ($self, $url) {
 sub find_existing_sessions ($self) {
 	my $sessions;
 	if (-d $self->target_dir()) {
-		for my $room (sort grep { $_->is_dir() } $self->target_dir()->children()) {
+		for my $room (sort grep { $_->is_dir() && !/^./ } $self->target_dir()->children()) {
 			for my $day (sort $room->children()) {
 				SESSION: for my $session (sort $day->children()) {
 					my ($code) = $session->basename() =~ m{([A-Z0-9]{6,6})$};
@@ -460,7 +460,7 @@ sub find_existing_sessions ($self) {
 
 
 sub cleanup ($self) {
-	for my $room (grep { $_->is_dir() } $self->target_dir()->children()) {
+	for my $room (grep { $_->is_dir() && !/^./ } $self->target_dir()->children()) {
 		for my $day ($room->children()) {
 			$self->remove_if_empty($day);
 		}


### PR DESCRIPTION

When using syncthing to later sync the directory syncthing places at .stfolder directory. RoomAssets-App-Sync chokes on those directories with:

`Can't locate object method "children" via package "Path::Class::File" at /srv/pretalxsync/app/bin/../lib/RoomAssets/App/Command/sync.pm line 443.`

and

`Can't locate object method "children" via package "Path::Class::File" at /srv/pretalxsync/app/bin/../lib/RoomAssets/App/Command/sync.pm line 473.`

Ignore hidden files when processing removal of rooms.